### PR TITLE
Force gem to use SSL secure connection by default

### DIFF
--- a/lib/api2cart/client.rb
+++ b/lib/api2cart/client.rb
@@ -45,6 +45,7 @@ module Api2cart
         Net::HTTP.new request_url.host, request_url.port
       end.tap do |net_http|
         net_http.read_timeout = READ_TIMEOUT
+        net_http.use_ssl = true
       end
     end
   end

--- a/lib/api2cart/request_url_composer.rb
+++ b/lib/api2cart/request_url_composer.rb
@@ -10,7 +10,7 @@ module Api2cart
               to: :Api2cart
 
     def compose_request_url
-      URI::HTTP.build host: host, path: full_path, query: query_string
+      URI::HTTPS.build host: host, path: full_path, query: query_string
     end
 
     protected

--- a/spec/api2cart/request_url_composer_spec.rb
+++ b/spec/api2cart/request_url_composer_spec.rb
@@ -17,7 +17,7 @@ describe Api2cart::RequestUrlComposer do
     subject { composed_url.scheme }
 
     specify do
-      expect(subject).to eq('http')
+      expect(subject).to eq('https')
     end
   end
 
@@ -102,7 +102,7 @@ describe Api2cart::RequestUrlComposer do
 
     context 'when host is default' do
       it do
-        is_expected.to eq 'http://api.api2cart.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
+        is_expected.to eq 'https://api.api2cart.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
       end
     end
 
@@ -112,7 +112,7 @@ describe Api2cart::RequestUrlComposer do
       before { Api2cart.configure{ |config| config.host = 'host.com' } }
 
       it do
-        is_expected.to eq 'http://host.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
+        is_expected.to eq 'https://host.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
       end
 
       after { Api2cart.configure{ |config| config.host = current_host } }
@@ -124,7 +124,7 @@ describe Api2cart::RequestUrlComposer do
       before { Api2cart.configure{ |config| config.api_version = '1.1' } }
 
       it do
-        is_expected.to eq 'http://api.api2cart.com/v1.1/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
+        is_expected.to eq 'https://api.api2cart.com/v1.1/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
       end
 
       after { Api2cart.configure{ |config| config.api_version = current_api_version } }
@@ -137,7 +137,7 @@ describe Api2cart::RequestUrlComposer do
     let(:request_url_composer) { Api2cart::RequestUrlComposer.new(api_key, store_key, :product_count, nil) }
 
     it 'just does not add them to URL query' do
-      is_expected.to eq 'http://api.api2cart.com/v1.0/product.count.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&store_key=6f00bbf49f5ada8156506aba161408c6'
+      is_expected.to eq 'https://api.api2cart.com/v1.0/product.count.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&store_key=6f00bbf49f5ada8156506aba161408c6'
     end
   end
 end

--- a/spec/api2cart/with_proxy_spec.rb
+++ b/spec/api2cart/with_proxy_spec.rb
@@ -13,7 +13,7 @@ describe Api2cart do
       end
 
       it 'extracts hostname and port from proxy URL' do
-        expect(Net::HTTP).to receive(:new).with('api.api2cart.com', 80, 'anti-throttling-proxy.local', 1080).and_call_original
+        expect(Net::HTTP).to receive(:new).with('api.api2cart.com', 443, 'anti-throttling-proxy.local', 1080).and_call_original
         store_with_proxy.product_count
       end
     end
@@ -37,7 +37,7 @@ describe Api2cart do
       end
 
       it 'extracts hostname and port from proxy URL' do
-        expect(Net::HTTP).to receive(:new).with('api.api2cart.com', 80, 'anti-throttling-proxy.local', 1080).and_call_original
+        expect(Net::HTTP).to receive(:new).with('api.api2cart.com', 443, 'anti-throttling-proxy.local', 1080).and_call_original
         store_with_proxy.product_count
       end
     end

--- a/spec/vcr_cassettes/v1_0/erroneous_request.yml
+++ b/spec/vcr_cassettes/v1_0/erroneous_request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.api2cart.com/v1.0/product.count.json?api_key=wrong&store_key=even%20more%20wrong
+    uri: https://api.api2cart.com/v1.0/product.count.json?api_key=wrong&store_key=even%20more%20wrong
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/v1_0/successful_request.yml
+++ b/spec/vcr_cassettes/v1_0/successful_request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.api2cart.com/v1.0/product.count.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&store_key=6f00bbf49f5ada8156506aba161408c6
+    uri: https://api.api2cart.com/v1.0/product.count.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&store_key=6f00bbf49f5ada8156506aba161408c6
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/v1_1/erroneous_request.yml
+++ b/spec/vcr_cassettes/v1_1/erroneous_request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.api2cart.com/v1.1/product.count.json?api_key=wrong&store_key=even%20more%20wrong
+    uri: https://api.api2cart.com/v1.1/product.count.json?api_key=wrong&store_key=even%20more%20wrong
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/v1_1/successful_request.yml
+++ b/spec/vcr_cassettes/v1_1/successful_request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.api2cart.com/v1.1/product.count.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&store_key=6f00bbf49f5ada8156506aba161408c6
+    uri: https://api.api2cart.com/v1.1/product.count.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&store_key=6f00bbf49f5ada8156506aba161408c6
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Not urgent but noticed this when inspecting some things. This PR forces the use of the https protocol to ensure that all connections are secure.

Do you think it's okay to force (considering it only uses a remote connection) or should we make it configurable?